### PR TITLE
Build to au and us regions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,14 @@ go build
 
 Above will create the single file binary `jayoh` in the root.
 
+# Build AMI image
+
+Packer is used to build AMIs in the regions defined in `ami/ami.json`:
+
+```sh
+./build sh
+```
+
 # Run
 
 **Generate a new server key:**

--- a/cloud/ami.json
+++ b/cloud/ami.json
@@ -17,6 +17,7 @@
       "instance_type": "t2.micro",
       "ssh_username": "ec2-user",
       "ami_name": "jayoh SSH Jump Server {{user `version`}} {{timestamp}}",
+      "ami_regions": ["ap-southeast-2", "us-west-2"],
       "shutdown_behavior": "terminate",
       "tags": {
         "Name": "jayoh SSH Jump Server {{user `version`}}",


### PR DESCRIPTION
So that `./build ami` will produce an AMI in au and us regions.